### PR TITLE
Align export-ignores with actual repository artefacts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,12 @@
+# This file was partly modified by the lean package validator (http://git.io/lean-package-validator).
+
 # Exclude build/test files from the release
-/tests                  export-ignore
-/.git*                  export-ignore
-/.php-cs-fixer.dist.php export-ignore
-/phpstan.neon.dist      export-ignore
-/phpunit.xml            export-ignore
-/test-server.php        export-ignore
-/test-terminal.php      export-ignore
-/UPGRADING.md           export-ignore
+.gitattributes export-ignore
+.github/       export-ignore
+.gitignore     export-ignore
+LICENCE.md     export-ignore
+mago.toml      export-ignore
+phpunit.xml    export-ignore
+README.md      export-ignore
+tests/         export-ignore
+UPGRADING.md   export-ignore


### PR DESCRIPTION
Aligns export-ignores with actual repository artefacts. Not sure about `LICENSE.md`, `README.md`, and `UPGRADING.md`. Feel free to remove the entries for them.