### PR TITLE
Fixes a bug causing multiline list items to be clipped

### DIFF
--- a/src/Rules/ListRule.php
+++ b/src/Rules/ListRule.php
@@ -37,9 +37,15 @@ final class ListRule implements Rule, ProvidesFirstChar
             $parser->consumeWhile(Parser::NEW_LINE);
         }
 
-        $children = $childContent !== ''
-            ? $parser->withRules(new ListRule())->lex($childContent)[0]
-            : null;
+        $children = null;
+
+        if (substr_count($childContent, '-') > 0) {
+            $children = $parser->withRules(new ListRule())->lex($childContent)[0];
+        }
+
+        if ($children === null && $childContent !== '') {
+            $content .= ' ' . trim(preg_replace('/\s+/u', ' ', $childContent) ?? '');
+        }
 
         $item = new ListItem($content, $children);
 

--- a/tests/Rules/ListRuleTest.php
+++ b/tests/Rules/ListRuleTest.php
@@ -27,6 +27,14 @@ class ListRuleTest extends ParserTestCase
     }
 
     #[Test]
+    public function test_lex_multiline_items(): void
+    {
+        $html = (string) new Parser(highlighter: null, rules: [new ListRule()])->parse("- one\n   continued\n   further\n- two\n");
+
+        $this->assertSame('<ul><li>one continued further</li><li>two</li></ul>', $html);
+    }
+
+    #[Test]
     public function test_hyphen_without_whitespace_is_not_a_list(): void
     {
         $html = (string) new Parser(highlighter: null, rules: [new ListRule(), new TextRule()])->parse('-not list');


### PR DESCRIPTION
When list item text is wrapped onto multiple lines, e.g.:

```markdown

- First item
- A really long
  second item
- Third item
```
The list item is cut off resulting in output like this:

- First item
- A really long
- Third item

This PR fixes it.