### PR TITLE
fix(security): XSS via HTML attributes and code blocks

### DIFF
--- a/src/Rules/HeadingRule.php
+++ b/src/Rules/HeadingRule.php
@@ -37,7 +37,7 @@ final class HeadingRule implements Rule, ProvidesFirstChar
             $buffer = substr(string: $buffer, offset: 0, length: $idSeparator) |> trim(...);
         } else {
             // No id is specified, we'll slug the heading
-            $id = $buffer |> strtolower(...) |> (fn (string $x) => str_replace(' ', '-', $x));
+            $id = $buffer |> strtolower(...) |> (fn (string $x) => trim(preg_replace('/[^a-z0-9]+/', '-', $x), '-'));
         }
 
         return new HeadingToken(

--- a/src/Rules/HeadingRule.php
+++ b/src/Rules/HeadingRule.php
@@ -37,7 +37,7 @@ final class HeadingRule implements Rule, ProvidesFirstChar
             $buffer = substr(string: $buffer, offset: 0, length: $idSeparator) |> trim(...);
         } else {
             // No id is specified, we'll slug the heading
-            $id = $buffer |> strtolower(...) |> (fn (string $x) => trim(preg_replace('/[^a-z0-9]+/', '-', $x), '-'));
+            $id = $buffer |> mb_strtolower(...) |> (fn (string $x) => trim(preg_replace('/[^\p{L}\p{N}]+/u', '-', $x) ?? '', '-'));
         }
 
         return new HeadingToken(

--- a/src/Tokens/CodeToken.php
+++ b/src/Tokens/CodeToken.php
@@ -20,7 +20,7 @@ final readonly class CodeToken implements Token
             $content = $parser->highlighter->parse($this->content, $language);
             $language = $parser->highlighter->getCurrentLanguage()?->getName();
         } else {
-            $content = $this->content;
+            $content = htmlspecialchars($this->content, ENT_QUOTES);
         }
 
         $class = $language ? ' class="language-' . htmlspecialchars($language, ENT_QUOTES) . '"' : '';

--- a/src/Tokens/CodeToken.php
+++ b/src/Tokens/CodeToken.php
@@ -16,17 +16,14 @@ final readonly class CodeToken implements Token
     {
         $language = $this->language;
 
-        if (! $language && $parser->highlighter) {
-            $language = $parser->highlighter->fallbackLanguage?->getName();
-        }
-
         if ($parser->highlighter) {
             $content = $parser->highlighter->parse($this->content, $language);
+            $language = $parser->highlighter->getCurrentLanguage()?->getName();
         } else {
             $content = $this->content;
         }
 
-        $class = $language ? " class=\"language-{$language}\"" : '';
+        $class = $language ? ' class="language-' . htmlspecialchars($language, ENT_QUOTES) . '"' : '';
 
         return "<code{$class}>{$content}</code>";
     }

--- a/src/Tokens/DivToken.php
+++ b/src/Tokens/DivToken.php
@@ -39,7 +39,7 @@ final class DivToken implements Token
             ])
             ->parse($this->content);
 
-        $class = $this->class ? " class=\"{$this->class}\"" : '';
+        $class = $this->class ? ' class="' . htmlspecialchars($this->class, ENT_QUOTES) . '"' : '';
 
         return "<div{$class}>{$content}</div>";
     }

--- a/src/Tokens/HeadingToken.php
+++ b/src/Tokens/HeadingToken.php
@@ -25,7 +25,7 @@ final class HeadingToken implements Token
         $tag = "h{$this->level}";
 
         if ($this->id) {
-            $id = " id=\"{$this->id}\"";
+            $id = ' id="' . htmlspecialchars($this->id, ENT_QUOTES) . '"';
         } else {
             $id = '';
         }

--- a/src/Tokens/ImageToken.php
+++ b/src/Tokens/ImageToken.php
@@ -18,8 +18,8 @@ final readonly class ImageToken implements Token
             return $parser->imageFactory->create($this->src, $this->alt)->html;
         }
 
-        $alt = $this->alt ? " alt=\"{$this->alt}\"" : '';
+        $alt = $this->alt ? ' alt="' . htmlspecialchars($this->alt, ENT_QUOTES) . '"' : '';
 
-        return "<img src=\"{$this->src}\"{$alt}>";
+        return '<img src="' . htmlspecialchars($this->src, ENT_QUOTES) . '"' . $alt . '>';
     }
 }

--- a/src/Tokens/LinkToken.php
+++ b/src/Tokens/LinkToken.php
@@ -41,6 +41,6 @@ final class LinkToken implements Token
             $blank = ' target="_blank" rel="noopener noreferrer"';
         }
 
-        return "<a href=\"{$href}\"{$blank}>{$content}</a>";
+        return '<a href="' . htmlspecialchars($href, ENT_QUOTES) . "\"{$blank}>{$content}</a>";
     }
 }

--- a/src/Tokens/PreToken.php
+++ b/src/Tokens/PreToken.php
@@ -21,7 +21,7 @@ final readonly class PreToken implements Token
             $content = $parser->highlighter->parse($this->content, $language);
             $language = $parser->highlighter->getCurrentLanguage()?->getName();
         } else {
-            $content = $this->content;
+            $content = htmlspecialchars($this->content, ENT_QUOTES);
         }
 
         $class = $language ? ' class="language-' . htmlspecialchars($language, ENT_QUOTES) . '"' : '';

--- a/src/Tokens/PreToken.php
+++ b/src/Tokens/PreToken.php
@@ -17,22 +17,19 @@ final readonly class PreToken implements Token
     {
         $language = $this->language;
 
-        if (! $language && $parser->highlighter) {
-            $language = $parser->highlighter->fallbackLanguage?->getName();
-        }
-
         if ($parser->highlighter) {
             $content = $parser->highlighter->parse($this->content, $language);
+            $language = $parser->highlighter->getCurrentLanguage()?->getName();
         } else {
             $content = $this->content;
         }
 
-        $class = $language ? " class=\"language-{$language}\"" : '';
+        $class = $language ? ' class="language-' . htmlspecialchars($language, ENT_QUOTES) . '"' : '';
 
         $html = "<pre{$class}>{$content}</pre>";
 
         if ($this->title) {
-            $html = "<div class=\"code-title\">{$this->title}</div>{$html}";
+            $html = '<div class="code-title">' . htmlspecialchars($this->title, ENT_QUOTES) . "</div>{$html}";
         }
 
         return $html;

--- a/tests/Rules/HeadingRuleTest.php
+++ b/tests/Rules/HeadingRuleTest.php
@@ -32,4 +32,20 @@ class HeadingRuleTest extends ParserTestCase
 
         $this->assertSame('<h3 id="hello-world">Hello</h3>', $html);
     }
+
+    #[Test]
+    public function test_slug_is_constrained_to_a_safe_alphabet(): void
+    {
+        $html = (string) new Parser(highlighter: null, rules: [new HeadingRule()])->parse('# Hello, "World" & Friends!');
+
+        $this->assertSame('<h1 id="hello-world-friends">Hello, "World" & Friends!</h1>', $html);
+    }
+
+    #[Test]
+    public function test_slug_cannot_break_out_of_the_id_attribute(): void
+    {
+        $html = (string) new Parser(highlighter: null, rules: [new HeadingRule()])->parse('# h " onclick="alert(1)');
+
+        $this->assertSame('<h1 id="h-onclick-alert-1">h " onclick="alert(1)</h1>', $html);
+    }
 }

--- a/tests/Rules/PreRuleTest.php
+++ b/tests/Rules/PreRuleTest.php
@@ -18,7 +18,7 @@ class PreRuleTest extends ParserTestCase
         ```
         MD);
 
-        $this->assertSame('<pre class="language-php">echo "hi";</pre>', $html);
+        $this->assertSame('<pre class="language-php">echo &quot;hi&quot;;</pre>', $html);
     }
 
     #[Test]
@@ -30,7 +30,7 @@ class PreRuleTest extends ParserTestCase
         ```
         MD);
 
-        $this->assertSame('<div class="code-title">file.php</div><pre class="language-php">echo "hi";</pre>', $html);
+        $this->assertSame('<div class="code-title">file.php</div><pre class="language-php">echo &quot;hi&quot;;</pre>', $html);
     }
 
     #[Test]
@@ -42,7 +42,7 @@ class PreRuleTest extends ParserTestCase
         ```
         MD);
 
-        $this->assertSame('<pre>echo "hi";</pre>', $html);
+        $this->assertSame('<pre>echo &quot;hi&quot;;</pre>', $html);
     }
 
     #[Test]

--- a/tests/Tokens/CodeTokenTest.php
+++ b/tests/Tokens/CodeTokenTest.php
@@ -30,7 +30,7 @@ class CodeTokenTest extends ParserTestCase
     {
         $token = new CodeToken('php', 'echo "hi";');
 
-        $this->assertEquals('<code class="language-php">echo "hi";</code>', $token->parse(new Parser(highlighter: null)));
+        $this->assertEquals('<code class="language-php">echo &quot;hi&quot;;</code>', $token->parse(new Parser(highlighter: null)));
     }
 
     #[Test]

--- a/tests/Tokens/CodeTokenTest.php
+++ b/tests/Tokens/CodeTokenTest.php
@@ -32,4 +32,20 @@ class CodeTokenTest extends ParserTestCase
 
         $this->assertEquals('<code class="language-php">echo "hi";</code>', $token->parse(new Parser(highlighter: null)));
     }
+
+    #[Test]
+    public function test_parse_resolves_unknown_language_to_fallback(): void
+    {
+        $token = new CodeToken('a"onmouseover="alert(1)', 'code');
+
+        $this->assertEquals('<code class="language-txt">code</code>', $token->parse(new Parser()));
+    }
+
+    #[Test]
+    public function test_parse_escapes_quotes_in_language(): void
+    {
+        $token = new CodeToken('a"onmouseover="alert(1)', 'code');
+
+        $this->assertEquals('<code class="language-a&quot;onmouseover=&quot;alert(1)">code</code>', $token->parse(new Parser(highlighter: null)));
+    }
 }

--- a/tests/Tokens/DivTokenTest.php
+++ b/tests/Tokens/DivTokenTest.php
@@ -34,6 +34,14 @@ class DivTokenTest extends ParserTestCase
     }
 
     #[Test]
+    public function test_parse_escapes_quotes_in_class(): void
+    {
+        $token = new DivToken(class: 'x" onmouseover="alert(1)', content: 'Hello');
+
+        $this->assertEquals('<div class="x&quot; onmouseover=&quot;alert(1)">Hello</div>', $token->parse(new Parser()));
+    }
+
+    #[Test]
     public function test_parse_with_bold(): void
     {
         $token = new DivToken(class: null, content: 'Hello **world**');

--- a/tests/Tokens/HeadingTokenTest.php
+++ b/tests/Tokens/HeadingTokenTest.php
@@ -34,6 +34,14 @@ class HeadingTokenTest extends ParserTestCase
     }
 
     #[Test]
+    public function test_parse_escapes_quotes_in_id(): void
+    {
+        $token = new HeadingToken('h', 1, 'h-" onclick="alert(1)');
+
+        $this->assertEquals('<h1 id="h-&quot; onclick=&quot;alert(1)">h</h1>', $token->parse(new Parser()));
+    }
+
+    #[Test]
     public function test_parse_with_bold(): void
     {
         $token = new HeadingToken('Hello, **world**!', 1);

--- a/tests/Tokens/ImageTokenTest.php
+++ b/tests/Tokens/ImageTokenTest.php
@@ -44,6 +44,22 @@ class ImageTokenTest extends ParserTestCase
     }
 
     #[Test]
+    public function test_parse_escapes_quotes_in_src(): void
+    {
+        $token = new ImageToken('x" onerror="alert(1)', null);
+
+        $this->assertEquals('<img src="x&quot; onerror=&quot;alert(1)">', $token->parse(new Parser()));
+    }
+
+    #[Test]
+    public function test_parse_escapes_quotes_in_alt(): void
+    {
+        $token = new ImageToken('img.png', 'a" onerror="alert(1)');
+
+        $this->assertEquals('<img src="img.png" alt="a&quot; onerror=&quot;alert(1)">', $token->parse(new Parser()));
+    }
+
+    #[Test]
     public function test_with_responsive_image(): void
     {
         $config = new ResponsiveImageConfig(

--- a/tests/Tokens/LinkTokenTest.php
+++ b/tests/Tokens/LinkTokenTest.php
@@ -74,6 +74,14 @@ class LinkTokenTest extends ParserTestCase
     }
 
     #[Test]
+    public function test_parse_escapes_quotes_in_href(): void
+    {
+        $token = new LinkToken('a', 'x" onclick="alert(1)');
+
+        $this->assertEquals('<a href="x&quot; onclick=&quot;alert(1)">a</a>', $token->parse(new Parser()));
+    }
+
+    #[Test]
     public function test_inline_formatting_rule_priority(): void
     {
         $parser = new Parser();

--- a/tests/Tokens/PreTokenTest.php
+++ b/tests/Tokens/PreTokenTest.php
@@ -37,7 +37,18 @@ class PreTokenTest extends ParserTestCase
         $token = new PreToken(language: null, content: 'echo "hi";');
 
         $this->assertEquals(
-            '<pre>echo "hi";</pre>',
+            '<pre>echo &quot;hi&quot;;</pre>',
+            $token->parse(new Parser(highlighter: null)),
+        );
+    }
+
+    #[Test]
+    public function test_parse_without_highlighter_escapes_content(): void
+    {
+        $token = new PreToken(language: null, content: '</pre><script>alert(1)</script>');
+
+        $this->assertEquals(
+            '<pre>&lt;/pre&gt;&lt;script&gt;alert(1)&lt;/script&gt;</pre>',
             $token->parse(new Parser(highlighter: null)),
         );
     }

--- a/tests/Tokens/PreTokenTest.php
+++ b/tests/Tokens/PreTokenTest.php
@@ -52,4 +52,26 @@ class PreTokenTest extends ParserTestCase
             $token->parse(new Parser()),
         );
     }
+
+    #[Test]
+    public function test_parse_resolves_unknown_language_to_fallback(): void
+    {
+        $token = new PreToken(language: 'a"onmouseover="alert(1)', content: 'code');
+
+        $this->assertEquals(
+            '<pre class="language-txt">code</pre>',
+            $token->parse(new Parser()),
+        );
+    }
+
+    #[Test]
+    public function test_parse_escapes_quotes_in_language(): void
+    {
+        $token = new PreToken(language: 'a"onmouseover="alert(1)', content: 'code');
+
+        $this->assertEquals(
+            '<pre class="language-a&quot;onmouseover=&quot;alert(1)">code</pre>',
+            $token->parse(new Parser(highlighter: null)),
+        );
+    }
 }


### PR DESCRIPTION
## Issue

Attribute values (`href`, `src`, `alt`, `class`, `id`) and un-highlighted code blocks were interpolated into HTML without escaping, so markdown input could break out of an attribute and cause an XSS injection.

```php
new Markdown()->parse('[click](https://evil.co" onclick="alert(1))')->html;
// before: <p><a href="https://evil.co" onclick="alert(1">click</a>)</p>
// after:  <p><a href="https://evil.co&quot; onclick=&quot;alert(1">click</a>)</p>
```

## Changes

- Escape HTML attribute values in token rendering
- Escape code blocks with `highlighter: null`
- Generate a proper slug for auto heading IDs
- Expand heading auto slugs to non-Latin languages