### PR TITLE
fix(parser): forToken cache leak

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -39,7 +39,7 @@ final class Parser
     private(set) array $perCharRules = [];
 
     /** @var \Tempest\Markdown\Parser[] */
-    private static array $cache = [];
+    private array $cache = [];
 
     public function __construct(
         public ?Highlighter $highlighter = new Highlighter(),
@@ -65,22 +65,17 @@ final class Parser
         $this->setRules($rules);
     }
 
-    public static function reset(): void
-    {
-        self::$cache = [];
-    }
-
     public function forToken(Token $token, array $rules): self
     {
-        if (isset(self::$cache[$token::class])) {
-            return self::$cache[$token::class];
+        if (isset($this->cache[$token::class])) {
+            return $this->cache[$token::class];
         }
 
         $clone = clone $this;
 
         $clone->setRules($rules);
 
-        self::$cache[$token::class] = $clone;
+        $this->cache[$token::class] = $clone;
 
         return $clone;
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -119,4 +119,15 @@ final class ParserTest extends ParserTestCase
         $this->assertTrue($parser->comesNext('_', offset: 2));
         $this->assertFalse($parser->comesNext('_', offset: 10));
     }
+
+    #[Test]
+    public function test_configuration_does_not_leak_between_instances(): void
+    {
+        $withHighlighter = new Parser();
+        $withHighlighter->parse('`x`');
+
+        $noHighlighter = new Parser(highlighter: null);
+
+        $this->assertSame('<p><code><b>x</b></code></p>', $noHighlighter->parse('`<b>x</b>`')->html);
+    }
 }

--- a/tests/ParserTestCase.php
+++ b/tests/ParserTestCase.php
@@ -2,15 +2,6 @@
 
 namespace Tempest\Markdown\Tests;
 
-use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
-use Tempest\Markdown\Parser;
 
-abstract class ParserTestCase extends TestCase
-{
-    #[Before]
-    public function resetParser(): void
-    {
-        Parser::reset();
-    }
-}
+abstract class ParserTestCase extends TestCase {}


### PR DESCRIPTION
## Issue

`Parser::$cache` was `static`, so sub-parsers created by `forToken()` were shared across every `Parser` instance in the process. The first instance to parse a given token type "won" and its configuration was baked into the cached clone and silently reused by all later instances, regardless of how they were configured.

```php
$first = new Parser();
$first->parse('`x`');

$second = new Parser(highlighter: null);
$second->parse('`<b>x</b>`')->html;
// before: rendered by the cached sub-parser from $first, using its highlighter
// after: rendered with $second's own configuration
```

Once there are more configuration options like security settings `new Markdown(allowedUrlPrefixes: [])` and so on this becomes a way bigger issue.

## Changes

- Scope `forToken` cache per instance
- Add cache leak regression test