### PR TITLE
feat(parser): add configurable maxNestingDepth

### DIFF
--- a/src/Exceptions/MaximumNestingDepthWasExceeded.php
+++ b/src/Exceptions/MaximumNestingDepthWasExceeded.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tempest\Markdown\Exceptions;
+
+use Exception;
+use Tempest\Markdown\MarkdownException;
+
+final class MaximumNestingDepthWasExceeded extends Exception implements MarkdownException
+{
+    public function __construct(int $maxNestingDepth)
+    {
+        parent::__construct("Maximum nesting depth of {$maxNestingDepth} was exceeded");
+    }
+}

--- a/src/Markdown.php
+++ b/src/Markdown.php
@@ -12,10 +12,12 @@ final class Markdown
     public function __construct(
         public ?Highlighter $highlighter = new Highlighter(),
         private ?ResponsiveImageFactory $imageFactory = null,
+        public int $maxNestingDepth = Parser::DEFAULT_MAX_NESTING_DEPTH,
     ) {
         $this->parser = new Parser(
             $this->highlighter,
             $this->imageFactory,
+            $this->maxNestingDepth,
         );
     }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -3,6 +3,7 @@
 namespace Tempest\Markdown;
 
 use Tempest\Highlight\Highlighter;
+use Tempest\Markdown\Exceptions\MaximumNestingDepthWasExceeded;
 use Tempest\Markdown\Rules\DivRule;
 use Tempest\Markdown\Rules\FrontMatterRule;
 use Tempest\Markdown\Rules\HeadingRule;
@@ -25,6 +26,7 @@ final class Parser
 {
     public const string WHITESPACE = "\r\n\t\f ";
     public const string NEW_LINE = "\r\n";
+    public const int DEFAULT_MAX_NESTING_DEPTH = 128;
 
     private(set) int $position = 0;
     private(set) int $length = 0;
@@ -41,9 +43,12 @@ final class Parser
     /** @var \Tempest\Markdown\Parser[] */
     private array $cache = [];
 
+    private static int $depth = 0;
+
     public function __construct(
         public ?Highlighter $highlighter = new Highlighter(),
         public ?ResponsiveImageFactory $imageFactory = null,
+        public int $maxNestingDepth = self::DEFAULT_MAX_NESTING_DEPTH,
         array $rules = [
             new NewLineRule(),
             new RawRule(),
@@ -184,51 +189,74 @@ final class Parser
 
     public function lex(string $content): TokenCollection
     {
-        $parser = clone $this;
+        $this->increaseNestingDepth();
 
-        $parser->setContent($content);
+        try {
+            $parser = clone $this;
 
-        $tokens = [];
+            $parser->setContent($content);
 
-        while ($parser->current !== null) {
-            foreach ($parser->perCharRules[$parser->current] ?? $parser->defaultRules as $rule) {
-                if (! $rule->shouldParse($parser)) {
-                    continue;
+            $tokens = [];
+
+            while ($parser->current !== null) {
+                foreach ($parser->perCharRules[$parser->current] ?? $parser->defaultRules as $rule) {
+                    if (! $rule->shouldParse($parser)) {
+                        continue;
+                    }
+
+                    $token = $rule->parse($parser);
+
+                    if ($token instanceof Token) {
+                        $tokens[] = $token;
+                        $parser->lastToken = $token;
+                    }
+
+                    continue 2;
                 }
 
-                $token = $rule->parse($parser);
-
-                if ($token instanceof Token) {
-                    $tokens[] = $token;
-                    $parser->lastToken = $token;
-                }
-
-                continue 2;
+                $parser->consume();
             }
 
-            $parser->consume();
+            return new TokenCollection($tokens);
+        } finally {
+            self::$depth--;
         }
-
-        return new TokenCollection($tokens);
     }
 
     public function parse(string $content): ParsedMarkdown
     {
-        $tokens = $this->lex($content);
+        $this->increaseNestingDepth();
 
-        $html = '';
+        try {
+            $tokens = $this->lex($content);
 
-        $frontMatter = [];
+            $html = '';
 
-        foreach ($tokens as $token) {
-            $html .= $token->parse($this);
+            $frontMatter = [];
 
-            if ($token instanceof FrontMatterToken) {
-                $frontMatter = [...$frontMatter, ...$token->data];
+            foreach ($tokens as $token) {
+                $html .= $token->parse($this);
+
+                if ($token instanceof FrontMatterToken) {
+                    $frontMatter = [...$frontMatter, ...$token->data];
+                }
             }
+
+            return new ParsedMarkdown($html, $frontMatter);
+        } finally {
+            self::$depth--;
+        }
+    }
+
+    // Guards both recursion paths: nested lists recurse through lex(), nested tokens through parse().
+    // Each caller decrements self::$depth in a finally block.
+    private function increaseNestingDepth(): void
+    {
+        if (self::$depth >= $this->maxNestingDepth) {
+            throw new MaximumNestingDepthWasExceeded($this->maxNestingDepth);
         }
 
-        return new ParsedMarkdown($html, $frontMatter);
+        self::$depth++;
     }
 
     public function comesNext(string $search, ?int $length = null, int $offset = 0): bool

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -3,6 +3,7 @@
 namespace Tempest\Markdown\Tests;
 
 use PHPUnit\Framework\Attributes\Test;
+use Tempest\Markdown\Exceptions\MaximumNestingDepthWasExceeded;
 use Tempest\Markdown\Parser;
 use Tempest\Markdown\Rules\HeadingRule;
 use Tempest\Markdown\Rules\ParagraphRule;
@@ -129,5 +130,30 @@ final class ParserTest extends ParserTestCase
         $noHighlighter = new Parser(highlighter: null);
 
         $this->assertSame('<p><code><b>x</b></code></p>', $noHighlighter->parse('`<b>x</b>`')->html);
+    }
+
+    #[Test]
+    public function test_max_nesting_depth_limits_nested_tokens(): void
+    {
+        $this->expectException(MaximumNestingDepthWasExceeded::class);
+
+        new Parser(maxNestingDepth: 3)->parse('Hello **world**');
+    }
+
+    #[Test]
+    public function test_max_nesting_depth_limits_nested_lists(): void
+    {
+        $this->expectException(MaximumNestingDepthWasExceeded::class);
+
+        new Parser(maxNestingDepth: 3)->parse("- one\n  - two\n    - three");
+    }
+
+    #[Test]
+    public function test_default_max_nesting_depth_allows_normal_content(): void
+    {
+        $html = (string) new Parser()->parse("Hello **bold** and **more bold**\n\n- one\n  - two");
+
+        $this->assertStringContainsString('<strong>bold</strong>', $html);
+        $this->assertStringContainsString('<li>', $html);
     }
 }


### PR DESCRIPTION
**--> Merge https://github.com/tempestphp/markdown/pull/22 first!**

## Issue

Deeply nested markdown (nested lists, nested inline tokens) recurses without bound, so user-provided input can crash the parser with a stack overflow, making it a denial-of-service (DoS) vector. Currently there is no way to limit nesting depth so this PR adds one.

### Solution

```php
new Markdown(maxNestingDepth: 64)->parse($markdown)->html;
// before: PHP stack overflow on deeply nested input
// after:  throws MaximumNestingDepthWasExceeded (default limit: 128)
```

## Changes

- Add `maxNestingDepth` option to `Markdown` and `Parser` (default 128)
